### PR TITLE
Add pubsub to wmrc

### DIFF
--- a/wmrc.sh
+++ b/wmrc.sh
@@ -344,7 +344,7 @@ case "$1" in
         ;;
     'publish-event')
         shift 1
-        publish_event "$1"
+        publish_event "$*"
         ;;
     'logs')
         case "$2" in


### PR DESCRIPTION
## Add PubSub mechanism to wmrc

This PR adds PubSub capabilities to wmrc. Some of the considered approaches or points while choosing the solution were:

### Bookkeeper approach
- It would be possible to have a middleware (i.e. deamon wmrc module - let's call it "bookkeeper") that is tasked with managing the messages themselves. This would allow for some interesting features like ack, exactly-once/at-least-once delivery, message ordering, retry, and even dead letter queue and such. In this case, this module would have some form of a sync mechanism (best one I could think of was actually using tmpfs/ramfs with inotify to collect timestamped messages as hierarchies files, so basically using filesystem as a sync mechanism as it is inherently threadsafe), then once the messages were collected they could then be either used to directly wake up wmrc modules from the bookkeeper module, or send them to some unix socket and so on. In this solution, the bookkeeper module would basically do everything, while the modules that publish and subscribe to messages essentially only write the message, and the ack for the processed message.
- However, this solution, while simple for the implementation of dummy methods of publishing and handling, introduces complexity to wmrc itself, as it requires to have a module implemented that is always active. This somewhat defeats the current implementation that is in many ways stateless and dependentless. It would probably present quite a powerful mechanism, but it does not align with the wmrc itself and introduces something that is required in the DE configuration. It also introduces another layer of SPOF (single point of failure) as if the bookkeeper module fails, everything fails.

### Stateless approach - implemented 
- `libwmrc.sh` now exposes two (three) new functions:
  - `_subscribes_to` which essentially returns the contents of `WMRC_SUBSCRIBES_TO` env variables, which keeps for each module, to which events the module subscribes to.
  - `handles` is a magic method that the modules will implement and that is where the actual implementations will reside
  - `handle_event` essentially proxies to to handles, but it exists for allowing additional layers of logic to `libwmrc.sh`. For now, one interesting thing it does is check the env variable to see if event mode is even enabled, and whether the `handles` should be called at all depending on it.

- `wmrc.sh` now adds one new function and additional logic to `module_exec`
  - `publish_event` (`wmrc publish-event <name> [args...]`) is a function that calculates which modules should be invoked for the passed event name, and calls the calculated modules. It would be possible to structure this differently and have modules declare multiple handlers for the same event. Still, for now that is left to the implementation of the module itself, or rather its `handles` function.
  - every `module_exec` is essentially a publish, where the name of the event is the name of the module that was executed. There is a safeguard in the `publish_event` function that prevents circular invocations, though that might even be desirable in some cases, and it might be worth introducing a switch for that. 
  - Considering that it is possible to do `wmrc publish-event <name> [args...]`, this implies that the event name does not explicitly have to be the module name, it can actually be anything, as long as there are modules that subscribe to the event with such name. This allows modules (as they are just shell scripts) to execute this and trigger custom events when desired.

- This solution, the less overengineered one, leaves the logic in the `wmrc` relatively simple, though extendable, and does not introduce the complexity of having a SPOF external module handling everything. So it sacrifices complexity for the same or somewhat fewer features. 